### PR TITLE
chore: Update Maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,20 +48,20 @@
         <assertj.version>3.25.3</assertj.version>
 
         <!-- Maven plugins -->
-        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-        <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
+        <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
+        <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
-        <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-        <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
-        <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
-        <maven-project-info-reports-plugin>3.5.0</maven-project-info-reports-plugin>
-        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
-        <maven-versions-plugin.version>2.16.2</maven-versions-plugin.version>
-        <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
-        <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+        <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
+        <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
+        <maven-project-info-reports-plugin>3.9.0</maven-project-info-reports-plugin>
+        <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
+        <maven-versions-plugin.version>2.18.0</maven-versions-plugin.version>
+        <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
+        <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <jreleaser-maven-plugin.version>1.10.0</jreleaser-maven-plugin.version>
-        <maven-help-plugin.version>3.4.0</maven-help-plugin.version>
-        <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
+        <maven-help-plugin.version>3.5.1</maven-help-plugin.version>
+        <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
 
         <maven-central.url>https://s01.oss.sonatype.org/service/local</maven-central.url>
 


### PR DESCRIPTION
- Update maven-compiler-plugin to 3.14.0
- Update maven-install-plugin to 3.1.4
- Update maven-source-plugin to 3.3.1
- Update maven-site-plugin to 3.21.0
- Update maven-javadoc-plugin to 3.11.2
- Update maven-project-info-reports-plugin to 3.9.0
- Update maven-surefire-plugin to 3.5.2
- Update maven-versions-plugin to 2.18.0
- Update maven-release-plugin to 3.1.1
- Update maven-deploy-plugin to 3.1.4
- Update maven-help-plugin to 3.5.1
- Update maven-enforcer-plugin to 3.5.0